### PR TITLE
ci: allow release commits without husky hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,5 @@ jobs:
       - run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: 0
           NODE_AUTH_TOKEN: ""

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"


### PR DESCRIPTION
# Summary

## Changes

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`

## Checklist

- [x] I followed Conventional Commits
- [x] I updated/add tests where needed
- [x] I updated docs where needed
- [x] I considered Changelog/Release note impact
