### PR TITLE
chore: add shorol/presets module for scoped patterns (issue #38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./presets": {
+      "types": "./dist/presets.d.ts",
+      "import": "./dist/presets.js",
+      "require": "./dist/presets.cjs"
+    },
     "./llms.txt": "./docs/llms.txt",
     "./SKILL.md": "./docs/SKILL.md"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,3 +34,9 @@ export { regex } from "./builder";
  * ```
  */
 export * from "./regexes";
+
+/**
+ * Scoped presets for common patterns (uuid, hex color, etc.).
+ * Import from `shorol/presets` for module-scoped semantics.
+ */
+export * from "./presets";

--- a/src/presets.test.ts
+++ b/src/presets.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  hexColorPattern,
+  hexColorRegex,
+  presetsRegistry,
+  uuidPatternBasic,
+  uuidRegexBasic
+} from "./presets";
+
+describe("presets module", () => {
+  it("exposes a scoped presets registry", () => {
+    expect(presetsRegistry.uuidPatternBasic).toBe(uuidPatternBasic);
+    expect(presetsRegistry.hexColorPattern).toBe(hexColorPattern);
+    expect(presetsRegistry.uuidRegexBasic).toBeInstanceOf(RegExp);
+    expect(presetsRegistry.hexColorRegex).toBeInstanceOf(RegExp);
+  });
+
+  it("validates UUID v4 basic pattern", () => {
+    expect(uuidRegexBasic.test("f47ac10b-58cc-4372-a567-0e02b2c3d479")).toBe(true);
+    expect(uuidRegexBasic.test("F47AC10B-58CC-4372-A567-0E02B2C3D479")).toBe(true);
+    expect(uuidRegexBasic.test("not-a-uuid")).toBe(false);
+  });
+
+  it("validates hex color pattern", () => {
+    expect(hexColorRegex.test("#fff")).toBe(true);
+    expect(hexColorRegex.test("#ffffff")).toBe(true);
+    expect(hexColorRegex.test("abc123")).toBe(true);
+    expect(hexColorRegex.test("#abcd")) .toBe(false);
+  });
+});

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,0 +1,58 @@
+import { regex } from "./builder";
+
+/**
+ * shorol/presets
+ *
+ * Scoped, opinionated regex presets for common validation scenarios.
+ *
+ * These patterns are maintained as a separate module to keep the core
+ * builder API minimal and to provide an explicit scope for convenience
+ * use cases. Import from `shorol/presets` for best clarity in code.
+ */
+
+const HEX_CHARS = "0123456789abcdefABCDEF";
+
+/** Basic UUID v4 pattern (case-insensitive). */
+export const uuidBasicBuilder = () =>
+  regex()
+    .start()
+    .anyOf("0123456789abcdef").repeat(8)
+    .literal("-")
+    .anyOf("0123456789abcdef").repeat(4)
+    .literal("-")
+    .literal("4")
+    .anyOf("0123456789abcdef").repeat(3)
+    .literal("-")
+    .anyOf("89ab").anyOf("0123456789abcdef").repeat(3)
+    .literal("-")
+    .anyOf("0123456789abcdef").repeat(12)
+    .end();
+
+export const uuidPatternBasic = uuidBasicBuilder().toString();
+export const uuidRegexBasic = uuidBasicBuilder().toRegExp("i");
+
+/** Basic hex color pattern (allows optional leading # and shorthand or full form). */
+export const hexColorBuilder = () =>
+  regex()
+    .start()
+    .literal("#").optional()
+    .nonCapture((b) =>
+      b
+        .anyOf(HEX_CHARS)
+        .repeat(3)
+        .or((b2) => b2.anyOf(HEX_CHARS).repeat(6))
+    )
+    .end();
+
+export const hexColorPattern = hexColorBuilder().toString();
+export const hexColorRegex = hexColorBuilder().toRegExp();
+
+/** Registry helpers for full module discovery. */
+export const presetsRegistry = {
+  uuidBasicBuilder,
+  uuidPatternBasic,
+  uuidRegexBasic,
+  hexColorBuilder,
+  hexColorPattern,
+  hexColorRegex
+};


### PR DESCRIPTION
This PR adds a dedicated  module for scoped patterns and presets. Includes UUID v4 and hex color patterns + registry, plus tests. Closes #38.