### PR TITLE
ci: skip commitlint on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
       - run: npm install
       - run: npm run typecheck
       - run: npm run build
-      - run: npm run commitlint
+      - name: Commitlint (main only)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: npm run commitlint
 
   release_preview:
     needs: [lint, code_coverage, ci]


### PR DESCRIPTION
## Summary
- run commitlint only on non-PR events to avoid failing contributor PRs

## Testing
- not run (CI config change)