### PR TITLE
ci: enforce release branch merge policy

### DIFF
--- a/.github/workflows/merge-policy.yml
+++ b/.github/workflows/merge-policy.yml
@@ -1,0 +1,18 @@
+name: Merge Policy
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  enforce:
+    name: Merge Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate head branch
+        run: |
+          echo "PR from: ${{ github.head_ref }}"
+          if [[ "${{ github.head_ref }}" != release/* && "${{ github.head_ref }}" != hotfix/* ]]; then
+            echo "ERROR: PRs to main must come from release/* or hotfix/* branches."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,11 @@ Thanks for your interest in contributing!
 5. Ensure your commits follow Conventional Commits (used for automated releases).
 6. Open a pull request with a clear description of the change.
 
+## Release Branch Policy
+
+- PRs to `main` must come from `release/*` or `hotfix/*` branches.
+- Feature work should target the active release branch (e.g. `release/1.6.x`).
+
 ## Development Setup
 
 - Build: `npm run build`


### PR DESCRIPTION
## Summary
- require PRs to main to come from release/* or hotfix/* branches
- document release branch policy in CONTRIBUTING

## Testing
- not run (workflow change only)