### PR TITLE
feat: add letter helper

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -164,6 +164,11 @@ export class Builder {
     return this.addToken("\\w");
   }
 
+  /** Add a letter matcher (`[a-zA-Z]`). */
+  letter(): this {
+    return this.addToken("[a-zA-Z]");
+  }
+
   /** Add a whitespace matcher (`\\s`). */
   whitespace(): this {
     return this.addToken("\\s");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,11 @@ describe("shorol regex builder", () => {
     expect(pattern).toBe(".");
   });
 
+  it("supports letter() token", () => {
+    const pattern = regex().letter().toString();
+    expect(pattern).toBe("[a-zA-Z]");
+  });
+
   it("supports alternation on the previous token", () => {
     const pattern = regex().literal("yes").orLiteral("no").toString();
     expect(pattern).toBe("(?:yes|no)");


### PR DESCRIPTION
## Summary
- add letter() helper for [a-zA-Z]
- add test coverage

## Testing
- npm run test:coverage

Closes #64