### PR TITLE
feat: add matches helper

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -316,6 +316,11 @@ export class Builder {
     const finalFlags = flags ?? this.storedFlags;
     return new RegExp(this.toString(), finalFlags);
   }
+
+  /** Test the built `RegExp` against input. */
+  matches(input: string, flags?: string): boolean {
+    return this.toRegExp(flags).test(input);
+  }
 }
 
 /** Create a new regex builder. */

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -174,6 +174,11 @@ export class Builder {
     return this.addToken("\\s");
   }
 
+  /** Add a literal space character. */
+  space(): this {
+    return this.addToken(" ");
+  }
+
   /** Add a capturing group built by the provided callback. */
   group(fn: BuildFn): this {
     const child = fn(new Builder());

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -164,6 +164,11 @@ export class Builder {
     return this.addToken("\\w");
   }
 
+  /** Add a letter matcher (`[a-zA-Z]`). */
+  letter(): this {
+    return this.addToken("[a-zA-Z]");
+  }
+
   /** Add a whitespace matcher (`\\s`). */
   whitespace(): this {
     return this.addToken("\\s");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -43,6 +43,11 @@ describe("shorol regex builder", () => {
     expect(pattern).toBe("[a-zA-Z]");
   });
 
+  it("supports space() token", () => {
+    const pattern = regex().space().toString();
+    expect(pattern).toBe(" ");
+  });
+
   it("supports alternation on the previous token", () => {
     const pattern = regex().literal("yes").orLiteral("no").toString();
     expect(pattern).toBe("(?:yes|no)");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -48,6 +48,12 @@ describe("shorol regex builder", () => {
     expect(pattern).toBe(" ");
   });
 
+  it("supports matches() helper", () => {
+    const builder = regex().start().literal("cat").end();
+    expect(builder.matches("cat")).toBe(true);
+    expect(builder.matches("cats")).toBe(false);
+  });
+
   it("supports alternation on the previous token", () => {
     const pattern = regex().literal("yes").orLiteral("no").toString();
     expect(pattern).toBe("(?:yes|no)");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,11 @@ describe("shorol regex builder", () => {
     expect(pattern).toBe(".");
   });
 
+  it("supports letter() token", () => {
+    const pattern = regex().letter().toString();
+    expect(pattern).toBe("[a-zA-Z]");
+  });
+
   it("supports alternation on the previous token", () => {
     const pattern = regex().literal("yes").orLiteral("no").toString();
     expect(pattern).toBe("(?:yes|no)");


### PR DESCRIPTION
## Summary
- add matches(input) helper for quick checks
- add test coverage

## Testing
- npm run test:coverage

Closes #66