### PR TITLE
feat: export escapeLiteral helper

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -3,7 +3,11 @@ type BuildFn = (builder: Builder) => Builder;
 
 const META_CHARS = /[.*+?^${}()|[\]\\]/g;
 
-function escapeLiteral(input: string): string {
+/**
+ * Escape regex metacharacters in a literal string.
+ * Useful when storing or reusing escaped tokens outside the builder.
+ */
+export function escapeLiteral(input: string): string {
   return input.replace(META_CHARS, "\\$&");
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { regex } from "./index";
+import { escapeLiteral, regex } from "./index";
 
 describe("shorol regex builder", () => {
   it("escapes literals", () => {
     const pattern = regex().literal("a+b*").toString();
     expect(pattern).toBe("a\\+b\\*");
+  });
+
+  it("exports escapeLiteral helper", () => {
+    expect(escapeLiteral("a+b*")).toBe("a\\+b\\*");
   });
 
   it("supports anchors", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,18 @@ export { Builder } from "./builder";
 export { regex } from "./builder";
 
 /**
+ * Escape regex metacharacters in a literal string.
+ *
+ * @example
+ * ```ts
+ * import { escapeLiteral } from "shorol";
+ *
+ * escapeLiteral("a+b*"); // "a\\+b\\*"
+ * ```
+ */
+export { escapeLiteral } from "./builder";
+
+/**
  * Prebuilt regex registry helpers and patterns.
  *
  * @example


### PR DESCRIPTION
## Summary
- export `escapeLiteral` from the public API
- add JSDoc example and unit test

## Testing
- not run (not requested)

Closes #69
