### PR TITLE
feat: 1.8.x milestone — repeat aliases and flags validation

### DIFF
--- a/docs/api-signatures.md
+++ b/docs/api-signatures.md
@@ -34,6 +34,8 @@ This file is used by `doc-sync-check` to detect documentation drift for exported
 `Builder.zeroOrMore(): this`
 `Builder.oneOrMore(): this`
 `Builder.repeat(min: number, max?: number): this`
+`Builder.exactly(count: number): this`
+`Builder.between(min: number, max: number): this`
 `Builder.flags(flags: string): this`
 `Builder.global(): this`
 `Builder.ignoreCase(): this`

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -2,6 +2,7 @@
 type BuildFn = (builder: Builder) => Builder;
 
 const META_CHARS = /[.*+?^${}()|[\]\\]/g;
+const VALID_FLAGS = "gimsuy";
 
 /**
  * Escape regex metacharacters in a literal string.
@@ -288,8 +289,31 @@ export class Builder {
     return this.applyQuantifier(range);
   }
 
+  /** Alias for `repeat(count)`. Repeats the previous token exactly `count` times (`{n}`). */
+  exactly(count: number): this {
+    return this.repeat(count);
+  }
+
+  /** Alias for `repeat(min, max)`. Repeats the previous token between `min` and `max` times (`{min,max}`). */
+  between(min: number, max: number): this {
+    return this.repeat(min, max);
+  }
+
   /** Store default flags to use when calling `toRegExp()`. */
   flags(flags: string): this {
+    if (flags.length === 0) {
+      throw new Error("flags() requires at least one flag character");
+    }
+    for (const ch of flags) {
+      if (!VALID_FLAGS.includes(ch)) {
+        throw new Error(
+          `Invalid flag '${ch}'. Allowed flags are: g, i, m, s, u, y`
+        );
+      }
+    }
+    if (new Set(flags).size !== flags.length) {
+      throw new Error("flags() contains duplicate characters");
+    }
     this.storedFlags = flags;
     return this;
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -139,6 +139,21 @@ describe("shorol regex builder", () => {
     expect(re.flags).toBe("gi");
   });
 
+  it("rejects invalid flags in flags()", () => {
+    expect(() => regex().flags("z")).toThrow("Invalid flag 'z'");
+    expect(() => regex().flags("igz")).toThrow("Invalid flag 'z'");
+    expect(() => regex().flags("1")).toThrow("Invalid flag '1'");
+  });
+
+  it("rejects duplicate flags in flags()", () => {
+    expect(() => regex().flags("gg")).toThrow("contains duplicate characters");
+    expect(() => regex().flags("igi")).toThrow("contains duplicate characters");
+  });
+
+  it("rejects empty flags string", () => {
+    expect(() => regex().flags("")).toThrow("requires at least one flag character");
+  });
+
   it("appends helper flags to stored flags", () => {
     const re = regex().literal("hi").flags("im").global().toRegExp();
     expect(re.flags).toBe("gim");
@@ -181,6 +196,18 @@ describe("shorol regex builder", () => {
     expect(() => regex().literal("a").repeat(-1)).toThrow();
     expect(() => regex().literal("a").repeat(2, 1)).toThrow();
     expect(() => regex().literal("a").repeat(1, Number.NaN)).toThrow();
+  });
+
+  it("supports exactly() alias", () => {
+    const pattern = regex().literal("a").exactly(3).toString();
+    expect(pattern).toBe("a{3}");
+    expect(() => regex().literal("a").exactly(-1)).toThrow();
+  });
+
+  it("supports between() alias", () => {
+    const pattern = regex().literal("a").between(2, 5).toString();
+    expect(pattern).toBe("a{2,5}");
+    expect(() => regex().literal("a").between(2, 1)).toThrow();
   });
 
   it("validates character class inputs", () => {


### PR DESCRIPTION
## Changes

Implements the **1.8.x** milestone (Builder polish and validation hardening):

**#61 — Add repeat aliases**
- `Builder.exactly(count: number)` — alias for `repeat(count)`
- `Builder.between(min: number, max: number)` — alias for `repeat(min, max)`

**#62 — Validate flags() input**
- Rejects invalid flag characters (only `gimsuy` allowed)
- Rejects duplicate flags
- Rejects empty string

**Verification**
- [x] `npm test` — 46/46 passing
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run lint` — passes