### PR TITLE
fix: add .npmrc for NODE_AUTH_TOKEN auth in npm publish

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
The v1.8.0 release failed with 404 when publishing to npm. The `actions/setup-node` action creates a `~/.npmrc` with the auth token, but `npm publish` run via `@semantic-release/exec` may not pick it up correctly.

This adds a project-level `.npmrc` that explicitly wires `NODE_AUTH_TOKEN` for `registry.npmjs.org` auth, ensuring the token is always available during publish.