### PR TITLE
fix: prevent script injection in merge-policy.yml

### DIFF
--- a/.github/workflows/merge-policy.yml
+++ b/.github/workflows/merge-policy.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate head branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "PR from: ${{ github.head_ref }}"
-          if [[ "${{ github.head_ref }}" != release/* && "${{ github.head_ref }}" != hotfix/* ]]; then
+          echo "PR from: $HEAD_REF"
+          if [[ "$HEAD_REF" != release/* && "$HEAD_REF" != hotfix/* ]]; then
             echo "ERROR: PRs to main must come from release/* or hotfix/* branches."
             exit 1
           fi


### PR DESCRIPTION
## P0 - Security

`github.head_ref` (attacker-controlled) was interpolated directly into a shell `run:` block in `merge-policy.yml`. An attacker could set their branch name to something like `foo"; echo injected; #` to execute arbitrary commands in CI.

**Fix:** Move `github.head_ref` into a step `env:` variable and reference the quoted shell variable instead.

**Audit result:** All other workflow files (`ci.yml`, `release.yml`) already use `${{ }}` only in `if:` conditions, `with:` blocks, and `env:` values — none in `run:` shell bodies. No other injection vectors found.

**Semver:** none (CI only)
