### PR TITLE
feat!: harden builder validation and emit cleaner char-class patterns

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -35,11 +35,18 @@ function isGroup(token: string): boolean {
   return token.startsWith("(") && token.endsWith(")");
 }
 
+function isCharClass(token: string): boolean {
+  return token.startsWith("[") && token.endsWith("]");
+}
+
 function needsQuantifierGrouping(token: string): boolean {
   if (token.length <= 1) {
     return false;
   }
   if (isGroup(token)) {
+    return false;
+  }
+  if (isCharClass(token)) {
     return false;
   }
   if (token.startsWith("\\") && token.length === 2) {
@@ -57,6 +64,7 @@ export class Builder {
   private started = false;
   private ended = false;
   private storedFlags?: string;
+  private lastTokenQuantified = false;
 
   private ensureCanAdd(): void {
     if (this.ended) {
@@ -67,6 +75,7 @@ export class Builder {
   private addToken(token: string): this {
     this.ensureCanAdd();
     this.tokens.push(token);
+    this.lastTokenQuantified = false;
     return this;
   }
 
@@ -86,10 +95,17 @@ export class Builder {
   }
 
   private applyQuantifier(suffix: string): this {
+    this.ensureCanAdd();
     const index = this.requireLast();
     const token = this.getToken(index);
+    if (this.lastTokenQuantified) {
+      throw new Error(
+        "Cannot apply quantifier to an already-quantified token. Use an explicit group if nesting is intentional."
+      );
+    }
     const grouped = needsQuantifierGrouping(token) ? `(?:${token})` : token;
     this.tokens[index] = `${grouped}${suffix}`;
+    this.lastTokenQuantified = true;
     return this;
   }
 
@@ -146,8 +162,8 @@ export class Builder {
    * Bounds are escaped for safety.
    */
   range(from: string, to: string): this {
-    if (from.length === 0 || to.length === 0) {
-      throw new Error("range(from, to) requires non-empty bounds");
+    if ([...from].length !== 1 || [...to].length !== 1) {
+      throw new Error("range(from, to) requires each bound to be exactly one code point");
     }
     const escapedFrom = escapeCharClass(from);
     const escapedTo = escapeCharClass(to);
@@ -247,12 +263,24 @@ export class Builder {
     return this.addToken(`(?<!${child.toString()})`);
   }
 
-  /** Add alternation with the previous token, e.g. `(?:left|right)`. */
+  /**
+   * Alternation scoped to the immediately previous token.
+   * Only that token is wrapped in the alternation group.
+   *
+   * @example
+   * ```ts
+   * regex().literal("a").literal("b").orLiteral("c").toString()
+   * // => "a(?:b|c)"   -- only "b" is alternated, not "ab"
+   * ```
+   */
+  // TODO: whole-expression alternation should be considered for a future major version.
   or(fn: BuildFn): this {
+    this.ensureCanAdd();
     const index = this.requireLast();
     const left = this.getToken(index);
     const right = fn(new Builder()).toString();
     this.tokens[index] = `(?:${left}|${right})`;
+    this.lastTokenQuantified = false;
     return this;
   }
 
@@ -278,11 +306,11 @@ export class Builder {
 
   /** Repeat the previous token with an explicit range (`{min}` or `{min,max}`). */
   repeat(min: number, max?: number): this {
-    if (min < 0 || !Number.isFinite(min)) {
-      throw new Error("repeat(min, max) requires min >= 0");
+    if (min < 0 || !Number.isInteger(min)) {
+      throw new Error("repeat(min, max) requires min to be a non-negative integer");
     }
-    if (max !== undefined && (max < min || !Number.isFinite(max))) {
-      throw new Error("repeat(min, max) requires max >= min");
+    if (max !== undefined && (max < min || !Number.isInteger(max))) {
+      throw new Error("repeat(min, max) requires max to be a non-negative integer >= min");
     }
 
     const range = max === undefined ? `{${min}}` : `{${min},${max}}`;
@@ -366,6 +394,7 @@ export class Builder {
     next.started = this.started;
     next.ended = this.ended;
     next.storedFlags = this.storedFlags;
+    next.lastTokenQuantified = this.lastTokenQuantified;
     return next;
   }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -177,6 +177,42 @@ describe("shorol regex builder", () => {
     expect(() => regex().end().literal("a")).toThrow();
   });
 
+  it("blocks pattern mutations after end()", () => {
+    expect(() => regex().literal("a").end().optional()).toThrow("Cannot add tokens");
+    expect(() => regex().literal("a").end().orLiteral("b")).toThrow("Cannot add tokens");
+    expect(regex().literal("a").end().global().toRegExp().flags).toBe("g");
+    expect(regex().literal("a").end().flags("i").toRegExp().flags).toBe("i");
+  });
+
+  it("rejects nested quantifiers", () => {
+    expect(() => regex().literal("a").oneOrMore().oneOrMore()).toThrow("already-quantified");
+    expect(() => regex().literal("a").optional().zeroOrMore()).toThrow("already-quantified");
+    expect(() => regex().literal("a").repeat(2).oneOrMore()).toThrow("already-quantified");
+  });
+
+  it("allows literals ending in escaped metacharacters under quantifiers", () => {
+    expect(() => regex().literal("https?").oneOrMore()).not.toThrow();
+    expect(regex().literal("https?").oneOrMore().toString()).toBe("(?:https\\?)+");
+    expect(() => regex().literal("c++").oneOrMore()).not.toThrow();
+    expect(regex().literal("c++").oneOrMore().toString()).toBe("(?:c\\+\\+)+");
+  });
+
+  it("carries quantified state across clone", () => {
+    const base = regex().literal("a").oneOrMore();
+    const cloned = base.clone();
+    expect(() => cloned.oneOrMore()).toThrow("already-quantified");
+  });
+
+  it("accepts single code point in range()", () => {
+    const emoji = regex().range("😀", "😎").toString();
+    expect(emoji).toBe("[😀-😎]");
+  });
+
+  it("documents single-token-scope alternation", () => {
+    const pattern = regex().literal("a").literal("b").orLiteral("c").toString();
+    expect(pattern).toBe("a(?:b|c)");
+  });
+
   it("throws when applying quantifiers without a previous token", () => {
     expect(() => regex().optional()).toThrow();
     expect(() => regex().zeroOrMore()).toThrow();
@@ -190,18 +226,25 @@ describe("shorol regex builder", () => {
     expect(group).toBe("(ab)+");
     const digit = regex().digit().oneOrMore().toString();
     expect(digit).toBe("\\d+");
+    const charClass = regex().anyOf("abc").oneOrMore().toString();
+    expect(charClass).toBe("[abc]+");
+    const negClass = regex().noneOf("abc").oneOrMore().toString();
+    expect(negClass).toBe("[^abc]+");
   });
 
   it("validates repeat ranges", () => {
     expect(() => regex().literal("a").repeat(-1)).toThrow();
     expect(() => regex().literal("a").repeat(2, 1)).toThrow();
     expect(() => regex().literal("a").repeat(1, Number.NaN)).toThrow();
+    expect(() => regex().literal("a").repeat(2.5)).toThrow();
+    expect(() => regex().literal("a").repeat(1, 2.5)).toThrow();
   });
 
   it("supports exactly() alias", () => {
     const pattern = regex().literal("a").exactly(3).toString();
     expect(pattern).toBe("a{3}");
     expect(() => regex().literal("a").exactly(-1)).toThrow();
+    expect(() => regex().literal("a").exactly(1.5)).toThrow();
   });
 
   it("supports between() alias", () => {
@@ -214,6 +257,7 @@ describe("shorol regex builder", () => {
     expect(() => regex().anyOf([])).toThrow();
     expect(() => regex().noneOf("")).toThrow();
     expect(() => regex().range("", "a")).toThrow();
+    expect(() => regex().range("ab", "yz")).toThrow("one code point");
   });
 
   it("throws when or() is called without a previous token", () => {


### PR DESCRIPTION
## feat!: harden builder validation and emit cleaner char-class patterns

### Breaking changes

| Change | Before | After |
|--------|--------|-------|
| `end()` locks pattern mutation | `.end().optional()` → `a$?` | throws `"Cannot add tokens after end() anchor"` |
| `repeat()` rejects non-integers | `repeat(2.5)` → `a{2.5}` | throws `"requires min to be a non-negative integer"` |
| `range()` must have single code-point bounds | `range("ab","yz")` → `[ab-yz]` | throws `"requires each bound to be exactly one code point"` |
| Char classes no longer over-grouped | `anyOf("abc").oneOrMore()` → `(?:[abc])+` | `[abc]+` |
| Nested quantifiers rejected | `.oneOrMore().oneOrMore()` → `(?:a+)+` | throws `"Cannot apply quantifier to an already-quantified token"` |

### Non-breaking (same commit, needed by structural changes)
- Flags can still be set after `end()` (they are metadata, not pattern tokens)
- Literals ending in escaped metacharacters (`https?`, `c++`) work correctly under quantifiers
- `clone()` carries quantified state

### Migration guide
1. If you call `.end()` and then `.optional()`, `.zeroOrMore()`, `.oneOrMore()`, `.repeat()`, `.exactly()`, `.between()`, `.or()`, or `.orLiteral()` — remove those calls (pattern is already anchored at end)
2. If you pass non-integers to `repeat()` / `exactly()` / `between()` — use integers
3. If you pass multi-character strings to `range()` — use single code points
4. Pattern output has changed for char classes under quantifiers — regex behavior is identical
5. If you rely on the string output of `.toString()`, `.toRegExp().source`, or exported `*Pattern` / `*Regex` constants: char classes are no longer wrapped in `(?:...)` groups
