### PR TITLE
P2: tests, packaging, docs + new features (lazy, backref, d flag, unicodeProperty, raw, oneOf)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,25 +26,18 @@ Thanks for your interest in contributing!
 
 ## Regex Policy
 
-To keep regex readable and centralized, all regex patterns must live in `src/regexes.ts`.
+All regex patterns must be built with the fluent builder. Both `src/regexes.ts` (general-purpose registry) and `src/presets.ts` (scoped presets) follow this rule. Avoid inline regex literals in feature code.
 
-Example:
+### Naming Convention
 
-```ts
-import { regex } from "./builder";
-
-export const slugBuilder = () =>
-  regex().start().word().oneOrMore().nonCapture((b) => b.literal("-").word().oneOrMore()).zeroOrMore().end();
-
-export const slugPattern = slugBuilder().toString();
-export const slugRegex = slugBuilder().toRegExp();
-```
+- Export `<name>Builder` (factory function returning a Builder), `<name>Pattern` (raw string), and `<name>Regex` (compiled RegExp).
+- Presets use explicit, scoped names (e.g., `uuidPatternBasic`). See `docs/PRESETS_GUIDE.md`.
 
 ### Do / Don’t
 
 | Do | Don’t |
 | --- | --- |
-| Add new patterns to `src/regexes.ts` | Inline regex literals in feature code |
+| Add new patterns to `src/regexes.ts` or `src/presets.ts` | Inline regex literals in feature code |
 | Export both `Pattern` and `Regex` | Export only a raw `/.../` regex |
 | Use the fluent builder for clarity | Hand-write complex regex strings |
 

--- a/docs/api-signatures.md
+++ b/docs/api-signatures.md
@@ -7,11 +7,14 @@ This file is used by `doc-sync-check` to detect documentation drift for exported
 `class Builder`
 `Builder.start(): this`
 `Builder.end(): this`
+`Builder.lazy(): this`
 `Builder.literal(text: string): this`
 `Builder.anyOf(chars: string | string[]): this`
 `Builder.noneOf(chars: string | string[]): this`
 `Builder.range(from: string, to: string): this`
+`Builder.raw(str: string): this`
 `Builder.any(): this`
+`Builder.backreference(ref: number | string): this`
 `Builder.digit(): this`
 `Builder.word(): this`
 `Builder.wordBoundary(): this`
@@ -22,12 +25,15 @@ This file is used by `doc-sync-check` to detect documentation drift for exported
 `Builder.lineBreak(): this`
 `Builder.tab(): this`
 `Builder.group(fn: BuildFn): this`
+`Builder.hasIndices(): this`
 `Builder.namedGroup(name: string, fn: BuildFn): this`
 `Builder.nonCapture(fn: BuildFn): this`
 `Builder.lookahead(fn: BuildFn): this`
 `Builder.negativeLookahead(fn: BuildFn): this`
 `Builder.lookbehind(fn: BuildFn): this`
 `Builder.negativeLookbehind(fn: BuildFn): this`
+`Builder.oneOf(...alternatives: BuildFn[]): this`
+`Builder.oneOfLiteral(...alternatives: string[]): this`
 `Builder.or(fn: BuildFn): this`
 `Builder.orLiteral(text: string): this`
 `Builder.optional(): this`
@@ -42,6 +48,7 @@ This file is used by `doc-sync-check` to detect documentation drift for exported
 `Builder.multiline(): this`
 `Builder.dotAll(): this`
 `Builder.unicode(): this`
+`Builder.unicodeProperty(name: string, value?: string): this`
 `Builder.toString(): string`
 `Builder.toRegExp(flags?: string): RegExp`
 `Builder.matches(input: string, flags?: string): boolean`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,5 +1,3 @@
-shorol is a Type-Safe, Fluent Regex Builder for JS/TS. It is the primary alternative to SuperExpressive or VerbalExpressions.
-
 # shorol (AI-Native Regex Builder)
 
 shorol is a fluent, chainable regex builder for JavaScript/TypeScript that turns dense regex into readable, auditable code. It is zero-dependency, safe-by-default (literals are escaped), and produces both pattern strings and native `RegExp` objects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "doc-sync-check": "^1.3.0",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^9.1.0",
+        "fast-check": "^4.8.0",
         "husky": "^9.0.11",
         "prettier": "^3.2.5",
         "semantic-release": "^23.0.6",
@@ -4913,6 +4914,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-content-type-parse": {
@@ -9821,6 +9845,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "engines": {
     "node": ">=18"
   },
@@ -78,6 +79,7 @@
     "doc-sync-check": "^1.3.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.1.0",
+    "fast-check": "^4.8.0",
     "husky": "^9.0.11",
     "prettier": "^3.2.5",
     "semantic-release": "^23.0.6",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -297,7 +297,7 @@ export class Builder {
     return this.repeat(count);
   }
 
-  /** Match any of the given alternatives, e.g. `oneOf(cat, dog)` → `(?:cat|dog)`. */
+  /** Match any of the given alternatives, e.g. `oneOf(cat, dog)` => `(?:cat|dog)`. */
   oneOf(...alternatives: BuildFn[]): this {
     if (alternatives.length < 2) {
       throw new Error("oneOf() requires at least two alternatives");

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -2,7 +2,7 @@
 type BuildFn = (builder: Builder) => Builder;
 
 const META_CHARS = /[.*+?^${}()|[\]\\]/g;
-const VALID_FLAGS = "gimsuy";
+const VALID_FLAGS = "dgimsuy";
 
 /**
  * Escape regex metacharacters in a literal string.
@@ -56,6 +56,7 @@ export class Builder {
   private tokens: string[] = [];
   private started = false;
   private ended = false;
+  private lastTokenLazy = false;
   private storedFlags?: string;
 
   private ensureCanAdd(): void {
@@ -67,6 +68,7 @@ export class Builder {
   private addToken(token: string): this {
     this.ensureCanAdd();
     this.tokens.push(token);
+    this.lastTokenLazy = false;
     return this;
   }
 
@@ -90,6 +92,7 @@ export class Builder {
     const token = this.getToken(index);
     const grouped = needsQuantifierGrouping(token) ? `(?:${token})` : token;
     this.tokens[index] = `${grouped}${suffix}`;
+    this.lastTokenLazy = false;
     return this;
   }
 
@@ -294,6 +297,74 @@ export class Builder {
     return this.repeat(count);
   }
 
+  /** Match any of the given alternatives, e.g. `oneOf(cat, dog)` → `(?:cat|dog)`. */
+  oneOf(...alternatives: BuildFn[]): this {
+    if (alternatives.length < 2) {
+      throw new Error("oneOf() requires at least two alternatives");
+    }
+    const parts = alternatives.map((fn) => fn(new Builder()).toString());
+    return this.addToken(`(?:${parts.join("|")})`);
+  }
+
+  /** Convenience for `oneOf` with literal strings. */
+  oneOfLiteral(...alternatives: string[]): this {
+    return this.oneOf(...alternatives.map((s) => (b: Builder) => b.literal(s)));
+  }
+
+  /** Inject a raw regex string without escaping. Use sparingly for edge cases the builder does not cover. */
+  raw(str: string): this {
+    if (str.length === 0) {
+      throw new Error("raw(str) requires a non-empty string");
+    }
+    return this.addToken(str);
+  }
+
+  /** Add a Unicode property escape (`\\p{Name}` or `\\p{Name=Value}`). Requires the `u` flag at runtime. */
+  unicodeProperty(name: string, value?: string): this {
+    if (name.length === 0) {
+      throw new Error("unicodeProperty(name) requires a non-empty property name");
+    }
+    if (value !== undefined) {
+      if (value.length === 0) {
+        throw new Error("unicodeProperty(name, value) requires a non-empty value");
+      }
+      return this.addToken(`\\p{${name}=${value}}`);
+    }
+    return this.addToken(`\\p{${name}}`);
+  }
+
+  /** Add a backreference by group number (`\\n`) or group name (`\\k<name>`). */
+  backreference(ref: number | string): this {
+    if (typeof ref === "number") {
+      if (!Number.isInteger(ref) || ref < 1) {
+        throw new Error("backreference(n) requires a positive integer");
+      }
+      return this.addToken(`\\${ref}`);
+    }
+    if (ref.length === 0) {
+      throw new Error("backreference(name) requires a non-empty name");
+    }
+    return this.addToken(`\\k<${ref}>`);
+  }
+
+  /** Make the previous quantifier non-greedy (`??`, `*?`, `+?`, `{n}?`, `{n,m}?`). */
+  lazy(): this {
+    if (this.lastTokenLazy) {
+      throw new Error("lazy() can only be applied once");
+    }
+    const index = this.requireLast();
+    const token = this.getToken(index);
+    const lastChar = token[token.length - 1];
+    if (!lastChar || (!"*+?".includes(lastChar) && lastChar !== "}")) {
+      throw new Error(
+        "lazy() requires a preceding quantifier (optional, zeroOrMore, oneOrMore, or repeat)"
+      );
+    }
+    this.tokens[index] = `${token}?`;
+    this.lastTokenLazy = true;
+    return this;
+  }
+
   /** Alias for `repeat(min, max)`. Repeats the previous token between `min` and `max` times (`{min,max}`). */
   between(min: number, max: number): this {
     return this.repeat(min, max);
@@ -307,7 +378,7 @@ export class Builder {
     for (const ch of flags) {
       if (!VALID_FLAGS.includes(ch)) {
         throw new Error(
-          `Invalid flag '${ch}'. Allowed flags are: g, i, m, s, u, y`
+          `Invalid flag '${ch}'. Allowed flags are: d, g, i, m, s, u, y`
         );
       }
     }
@@ -354,6 +425,11 @@ export class Builder {
     return this.appendFlag("u");
   }
 
+  /** Enable hasIndices ("d") flag. */
+  hasIndices(): this {
+    return this.appendFlag("d");
+  }
+
   /** Build the raw regex pattern string. */
   toString(): string {
     return this.tokens.join("");
@@ -365,6 +441,7 @@ export class Builder {
     next.tokens = [...this.tokens];
     next.started = this.started;
     next.ended = this.ended;
+    next.lastTokenLazy = this.lastTokenLazy;
     next.storedFlags = this.storedFlags;
     return next;
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -127,6 +127,8 @@ describe("shorol regex builder", () => {
     expect(re.flags).toBe("i");
     const override = regex().literal("hi").flags("i").toRegExp("g");
     expect(override.flags).toBe("g");
+    const re2 = regex().literal("hi").flags("d").toRegExp();
+    expect(re2.flags).toBe("d");
   });
 
   it("supports convenience flag helpers", () => {
@@ -143,6 +145,7 @@ describe("shorol regex builder", () => {
     expect(() => regex().flags("z")).toThrow("Invalid flag 'z'");
     expect(() => regex().flags("igz")).toThrow("Invalid flag 'z'");
     expect(() => regex().flags("1")).toThrow("Invalid flag '1'");
+    expect(() => regex().flags("dz")).toThrow("Invalid flag 'z'");
   });
 
   it("rejects duplicate flags in flags()", () => {
@@ -159,9 +162,11 @@ describe("shorol regex builder", () => {
     expect(re.flags).toBe("gim");
   });
 
-  it("supports multiline, dotAll, and unicode helpers", () => {
+  it("supports multiline, dotAll, unicode, and hasIndices helpers", () => {
     const re = regex().literal("hi").multiline().dotAll().unicode().toRegExp();
     expect(re.flags).toBe("msu");
+    const re2 = regex().literal("hi").hasIndices().toRegExp();
+    expect(re2.flags).toBe("d");
   });
 
   it("builds RegExp with flags", () => {
@@ -169,6 +174,8 @@ describe("shorol regex builder", () => {
     expect(re).toBeInstanceOf(RegExp);
     expect(re.flags).toBe("i");
     expect(re.source).toBe("hi");
+    const re2 = regex().literal("hi").toRegExp("d");
+    expect(re2.flags).toBe("d");
   });
 
   it("enforces anchors and token sequencing rules", () => {
@@ -230,5 +237,77 @@ describe("shorol regex builder", () => {
   it("guards internal token access", () => {
     const builder = regex() as unknown as { getToken: (index: number) => string };
     expect(() => builder.getToken(0)).toThrow("Missing token at index");
+  });
+
+  it("lazy() makes the previous quantifier non-greedy", () => {
+    expect(regex().literal("a").optional().lazy().toString()).toBe("a??");
+    expect(regex().literal("a").zeroOrMore().lazy().toString()).toBe("a*?");
+    expect(regex().literal("a").oneOrMore().lazy().toString()).toBe("a+?");
+    expect(regex().literal("a").repeat(3).lazy().toString()).toBe("a{3}?");
+    expect(regex().literal("a").repeat(2, 5).lazy().toString()).toBe("a{2,5}?");
+  });
+
+  it("lazy() groups multi-char tokens", () => {
+    expect(regex().literal("ab").oneOrMore().lazy().toString()).toBe("(?:ab)+?");
+  });
+
+  it("lazy() throws without a quantifier", () => {
+    expect(() => regex().literal("a").lazy()).toThrow("lazy() requires a preceding quantifier");
+    expect(() => regex().start().lazy()).toThrow();
+    expect(() => regex().lazy()).toThrow();
+  });
+
+  it("lazy() throws when applied twice", () => {
+    expect(() => regex().literal("a").oneOrMore().lazy().lazy()).toThrow("lazy() can only be applied once");
+  });
+
+  it("backreference() by number adds \\n", () => {
+    expect(regex().backreference(1).toString()).toBe("\\1");
+    expect(regex().backreference(12).toString()).toBe("\\12");
+    expect(() => regex().backreference(0)).toThrow("positive integer");
+    expect(() => regex().backreference(-1)).toThrow("positive integer");
+    expect(() => regex().backreference(1.5)).toThrow("positive integer");
+  });
+
+  it("backreference() by name adds \\k<name>", () => {
+    expect(regex().backreference("name").toString()).toBe("\\k<name>");
+    expect(regex().backreference("group_1").toString()).toBe("\\k<group_1>");
+    expect(() => regex().backreference("")).toThrow("non-empty name");
+  });
+
+  it("unicodeProperty() adds \\p{Name}", () => {
+    expect(regex().unicodeProperty("Letter").toString()).toBe("\\p{Letter}");
+    expect(regex().unicodeProperty("Script", "Greek").toString()).toBe("\\p{Script=Greek}");
+    expect(() => regex().unicodeProperty("")).toThrow("non-empty property name");
+    expect(() => regex().unicodeProperty("Letter", "")).toThrow("non-empty value");
+  });
+
+  it("raw() injects without escaping", () => {
+    expect(regex().raw("\\d{3}").toString()).toBe("\\d{3}");
+    expect(regex().raw("(?=look)").toString()).toBe("(?=look)");
+    expect(() => regex().raw("")).toThrow("non-empty string");
+  });
+
+  it("raw() after end() still throws", () => {
+    expect(() => regex().end().raw("x")).toThrow();
+  });
+
+  it("oneOf() matches any alternative", () => {
+    expect(
+      regex().oneOf(
+        (b) => b.literal("cat"),
+        (b) => b.literal("dog"),
+        (b) => b.literal("bird")
+      ).toString()
+    ).toBe("(?:cat|dog|bird)");
+  });
+
+  it("oneOfLiteral() convenience with strings", () => {
+    expect(regex().oneOfLiteral("yes", "no", "maybe").toString()).toBe("(?:yes|no|maybe)");
+    expect(() => regex().oneOfLiteral("only")).toThrow("requires at least two alternatives");
+  });
+
+  it("oneOf() throws with less than 2 alternatives", () => {
+    expect(() => regex().oneOf((b) => b.literal("x"))).toThrow("requires at least two alternatives");
   });
 });

--- a/src/property.test.ts
+++ b/src/property.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { regex } from "./index";
+
+type BuilderMethod = (b: ReturnType<typeof regex>) => void;
+
+const methods: BuilderMethod[] = [
+  (b) => b.literal("a"),
+  (b) => b.literal("cat"),
+  (b) => b.digit(),
+  (b) => b.word(),
+  (b) => b.whitespace(),
+  (b) => b.any(),
+  (b) => b.letter(),
+  (b) => b.anyOf("abc"),
+  (b) => b.noneOf("xyz"),
+  (b) => b.range("0", "9"),
+  (b) => b.space(),
+  (b) => b.wordBoundary(),
+];
+
+function tryBuild(methods: BuilderMethod[]): string | null {
+  const builder = regex();
+  for (const m of methods) {
+    try {
+      m(builder);
+    } catch {
+      return null;
+    }
+  }
+  return builder.toString();
+}
+
+describe("property: builder output always compiles", () => {
+  it("toString() can always be passed to new RegExp", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom(...methods), { minLength: 1, maxLength: 10 }),
+        (cmds) => {
+          const pattern = tryBuild(cmds);
+          fc.pre(pattern !== null);
+          expect(() => new RegExp(pattern!)).not.toThrow();
+        }
+      )
+    );
+  });
+});
+
+describe("property: matches is consistent with RegExp.test", () => {
+  it("agrees for valid builder chains against arbitrary strings", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom(...methods), { minLength: 1, maxLength: 8 }),
+        fc.string(),
+        (cmds, input) => {
+          const pattern = tryBuild(cmds);
+          fc.pre(pattern !== null);
+          const builder = regex();
+          for (const m of cmds) {
+            m(builder);
+          }
+          const re = new RegExp(pattern!);
+          expect(builder.matches(input)).toBe(re.test(input));
+        }
+      )
+    );
+  });
+});


### PR DESCRIPTION
## P2 Work

### Tests & Packaging
- Add fast-check property tests: builder output always compiles, matches() agrees with RegExp.test()
- Add sideEffects: false for tree-shaking
- Add .github/dependabot.yml (npm, weekly)
- Add top-level permissions: contents: read to ci.yml
- Reconcile CONTRIBUTING.md regex policy (mention presets)
- Cut unverifiable line from docs/llms.txt

### New Features
- `lazy()` — make preceding quantifier non-greedy
- `backreference(n | name)` — numbered and named backreferences
- `hasIndices()` / `d` flag support
- `unicodeProperty(name, value?)` — Unicode property escapes
- `raw(str)` — inject raw regex without escaping
- `oneOf(...fn)` / `oneOfLiteral(...str)` — match any alternative

All tests pass (60), typecheck and lint clean.