### PR TITLE
ci: drop Node 18 (EOL), require >=20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Code Coverage
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     name: CI
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docs"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Node 18 is EOL since Oct 2025. The `rolldown` transitive dependency requires `node:util.styleText` (added in Node 21.7+), which breaks coverage on Node 18.\n\n- Drop Node 18 from CI matrix (keep 20, 22)\n- Update engines in package.json from >=18 to >=20