### PR TITLE
ci: drop Node 18 (EOL), require >=20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Code Coverage
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
     name: CI
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Same fix as PR #103 — Node 18 EOL, rolldown transitive dep requires Node 21.7+.\n\n- Drop Node 18 from CI matrix (keep 20, 22)\n- Update engines in package.json from >=18 to >=20