### PR TITLE
feat: use PR-based release instead of direct push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,44 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run release
+        id: release
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
+
+      - name: Create release PR and tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — no new release"
+            exit 0
+          fi
+
+          BRANCH="release/v$VERSION"
+          git checkout -b "$BRANCH"
+          git add package.json CHANGELOG.md
+          git commit -m "chore(release): $TAG [skip ci]"
+          git push origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): $TAG" \
+            --body "Automated release PR for $TAG" \
+            --label release)
+          gh pr merge "$PR_URL" \
+            --squash \
+            --admin \
+            --subject "chore(release): $TAG"
+
+          git checkout main
+          git pull origin main
+          git tag "$TAG"
+          git push origin "$TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,12 +17,6 @@
       }
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"]
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "labels": false,


### PR DESCRIPTION
Removes @semantic-release/git (which fails pushing to main due to branch protection) and replaces it with a workflow step that creates a release PR, merges it via admin bypass, and pushes the git tag.