### PR TITLE
fix: check git diff instead of tag existence in release PR step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,36 +39,30 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0
 
-      - name: Create release PR and tag
+      - name: Create release PR
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TAG="v$VERSION"
+          if ! git diff --quiet -- package.json; then
+            VERSION=$(node -p "require('./package.json').version")
+            TAG="v$VERSION"
+            BRANCH="release/v$VERSION"
 
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists — no new release"
-            exit 0
+            git checkout -b "$BRANCH"
+            git add package.json CHANGELOG.md
+            git commit -m "chore(release): $TAG [skip ci]"
+            git push origin "$BRANCH"
+
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(release): $TAG" \
+              --body "Automated release PR for $TAG" \
+              --label release)
+            gh pr merge "$PR_URL" \
+              --squash \
+              --admin \
+              --subject "chore(release): $TAG"
+          else
+            echo "No version bump detected — no release PR needed"
           fi
-
-          BRANCH="release/v$VERSION"
-          git checkout -b "$BRANCH"
-          git add package.json CHANGELOG.md
-          git commit -m "chore(release): $TAG [skip ci]"
-          git push origin "$BRANCH"
-
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(release): $TAG" \
-            --body "Automated release PR for $TAG" \
-            --label release)
-          gh pr merge "$PR_URL" \
-            --squash \
-            --admin \
-            --subject "chore(release): $TAG"
-
-          git checkout main
-          git pull origin main
-          git tag "$TAG"
-          git push origin "$TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous approach checked if the git tag existed, but @semantic-release/github creates the tag via API before the workflow can commit the version bump. Now checks if package.json was modified by semantic-release instead.