### PR TITLE
fix: allow dependabot branches in merge policy

### DIFF
--- a/.github/workflows/merge-policy.yml
+++ b/.github/workflows/merge-policy.yml
@@ -14,7 +14,7 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           echo "PR from: $HEAD_REF"
-          if [[ "$HEAD_REF" != release/* && "$HEAD_REF" != hotfix/* ]]; then
-            echo "ERROR: PRs to main must come from release/* or hotfix/* branches."
+          if [[ "$HEAD_REF" != release/* && "$HEAD_REF" != hotfix/* && "$HEAD_REF" != dependabot/* ]]; then
+            echo "ERROR: PRs to main must come from release/*, hotfix/*, or dependabot/* branches."
             exit 1
           fi


### PR DESCRIPTION
Adds dependabot/* to the list of allowed branch prefixes for PRs targeting main.