### PR TITLE
feat: auto-close dependabot PRs less than 2 weeks old

### DIFF
--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -1,0 +1,59 @@
+name: Dependabot Age Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-age:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const match = title.match(
+              /^chore\(deps(?:-dev)?\): bump (.+) from [\d.]+ to ([\d.]+)$/
+            );
+            if (!match) {
+              console.log(`Unrecognized title format: ${title}`);
+              return { package: '', version: '' };
+            }
+
+            const pkg = match[1];
+            const version = match[2];
+
+            const url = `https://registry.npmjs.org/${encodeURIComponent(pkg)}`;
+            const res = await fetch(url);
+            const data = await res.json();
+            const releaseDate = new Date(data.time[version]);
+            const now = new Date();
+            const daysOld = (now - releaseDate) / (1000 * 60 * 60 * 24);
+
+            console.log(`${pkg}@${version} released ${releaseDate.toISOString()} (${daysOld.toFixed(1)} days ago)`);
+
+            if (daysOld < 14) {
+              const reopenDate = new Date(releaseDate.getTime() + 14 * 24 * 60 * 60 * 1000);
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `⏳ This update was released only ${Math.round(daysOld)} days ago. ` +
+                      `It will be considered for merging after **${reopenDate.toISOString().split('T')[0]}** ` +
+                      `(2 weeks from release).\n\n` +
+                      `Reopen this PR after that date, or use \`@dependabot recreate\` to refresh.`
+              });
+              await github.rest.pulls.update({
+                ...context.repo,
+                pull_number: context.issue.number,
+                state: 'closed'
+              });
+              return { package: pkg, version, daysOld, closed: true };
+            }
+
+            return { package: pkg, version, daysOld, closed: false };


### PR DESCRIPTION
Adds a post-update workflow that checks each dependabot PR's npm release date. If the version is less than 14 days old, the PR is closed with a note about when it can be reopened.