### PR TITLE
fix: add Socket badge and enable npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
           HUSKY: 0
 
       - name: Create release PR

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![license](https://img.shields.io/npm/l/shorol.svg)](LICENSE)
 [![release](https://img.shields.io/github/v/release/chetanbasuray/shorol.svg)](https://github.com/chetanbasuray/shorol/releases)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/shorol.svg)](https://bundlephobia.com/package/shorol)
+[![Socket Badge](https://badge.socket.dev/npm/package/shorol/2.1.2)](https://badge.socket.dev/npm/package/shorol/2.1.2)
 
 Shorol is a fluent, human-readable regex builder for JavaScript and TypeScript. It helps teams generate regex
 that stays readable in code review, centralizes patterns in one place, and exports both pattern


### PR DESCRIPTION
Adds Socket badge to README and enables npm provenance attestation via `NPM_CONFIG_PROVENANCE=true` env var in the release workflow.

`@semantic-release/npm` v13.1.5 has `provenance: true` config but doesn't pass `--provenance` to `npm publish`. Setting the env var forces npm CLI to include the flag.