### PR TITLE
fix: revert semantic-release git plugin, main branch protection blocks it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
           HUSKY: 0
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,12 +17,6 @@
       }
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"]
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "labels": false,


### PR DESCRIPTION
## Summary
- Live-tested the release from #138 and it failed: the main branch ruleset only allows bypass for an admin repository role, and the release workflow's GITHUB_TOKEN does not hold that role. The git plugin's push was rejected with GH013 before the publish step ever ran, so npm publish and the GitHub release stopped happening entirely for this release.
- Nothing was published or tagged before the failure, so this is a clean revert point. Reverting .releaserc.json and release.yml to the pre-#138 state restores the previously working behavior: releases publish to npm and to GitHub, but package.json and CHANGELOG.md do not get committed back to main.
- Restoring the commit-back behavior needs either a bypass-capable token or a PR-based commit flow, both of which require a repository access decision that is not mine to make.

## Test plan
- [x] npx prettier --check on both changed files
- [x] JSON and YAML syntax validated
- [x] Diff is a clean revert of the two files touched by the git plugin change in #138