### PR TITLE
fix: open a manual-merge PR to sync version and changelog after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,33 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
           HUSKY: 0
+
+      - name: Open release sync PR
+        if: success()
+        run: |
+          if git diff --quiet -- package.json; then
+            echo "No version bump detected, nothing to sync"
+            exit 0
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          BRANCH="release/$TAG"
+
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): sync $TAG [skip ci]"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(release): sync $TAG" \
+            --body "Syncs package.json, package-lock.json, and CHANGELOG.md with the $TAG release already published to npm and GitHub. Requires manual review and merge, nothing here auto-merges." \
+            --label release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
## Summary
- The prior attempt to commit package.json/CHANGELOG.md back to main via @semantic-release/git failed outright: the branch ruleset only bypasses for an admin repository role, and the workflow token does not hold it.
- Fixing the required-status-check name mismatch was considered and rejected on purpose: it currently enforces that nothing merges to main without an explicit admin action, which is the desired behavior, not a bug.
- Added a step that opens a release/vX.Y.Z PR with the version bump and changelog after a successful release, and stops there. Nothing merges automatically; the PR waits for manual review and merge.

## Test plan
- [x] YAML syntax validated
- [x] npx prettier --check on the changed file
- [ ] Full behavior can only be confirmed on the next real release, since this step only runs when a version bump is detected