### PR TITLE
chore(release): sync v2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.7](https://github.com/chetanbasuray/shorol/compare/v2.1.6...v2.1.7) (2026-07-15)
+
+
+### Bug Fixes
+
+* open a manual-merge PR to sync version and changelog after release ([#140](https://github.com/chetanbasuray/shorol/issues/140)) ([4d967b5](https://github.com/chetanbasuray/shorol/commit/4d967b5d8fc24cf3e523f894ae0575b11193d811))
+
 ## [2.1.5](https://github.com/chetanbasuray/shorol/compare/v2.1.4...v2.1.5) (2026-06-28)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shorol",
-  "version": "2.1.5",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shorol",
-      "version": "2.1.5",
+      "version": "2.1.7",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shorol",
-  "version": "2.1.5",
+  "version": "2.1.7",
   "description": "Fluent, human-readable regex builder for JavaScript/TypeScript.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Syncs package.json, package-lock.json, and CHANGELOG.md with the v2.1.7 release already published to npm and GitHub. Requires manual review and merge, nothing here auto-merges.