### PR TITLE
fix: make releases manual and restrict triggers to fix, feat, and breaking changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,10 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  workflow_dispatch: {}
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: main
           fetch-depth: 0
       - run: git fetch --tags --force
       - uses: actions/setup-node@v4

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,18 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": false },
+          { "revert": true, "release": false }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
## Summary
- The release workflow ran automatically every time CI succeeded on main, so each merged PR became its own release and its own release sync PR, with no way to batch several issues into one release. Switched the trigger to workflow_dispatch: merge as many issue PRs as you want, then trigger a release yourself from the Actions tab (or gh workflow run Release) whenever ready. semantic-release already computes the bump from every commit since the last tag, so it naturally batches everything accumulated since the last release.
- Simplified the release-type rules to exactly three tiers: fix commits release a patch, feat commits release a minor, and a feat commit with a BREAKING CHANGE footer releases a major. perf and revert commits no longer trigger a release on their own (the previous default did release on those).
- Verified the rule set directly against @semantic-release/commit-analyzer rather than relying on a dry run: fix+chore+perf+docs resolves to patch, fix+feat resolves to minor, a BREAKING CHANGE footer resolves to major, and perf-only, revert-only, and chore-only all resolve to no release. Also confirmed the feat! bang shorthand does not work as a major marker with this repo's angular preset, so BREAKING CHANGE footers are the convention going forward.

## Test plan
- [x] YAML and JSON syntax validated
- [x] npx prettier --check on both changed files
- [x] Direct test against @semantic-release/commit-analyzer confirming all six commit-type combinations resolve as intended
- [ ] Full end-to-end confirmed on the next manually triggered release