### PR TITLE
fix: drop skip ci from release sync PR commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add package.json package-lock.json CHANGELOG.md
-          git commit -m "chore(release): sync $TAG [skip ci]"
+          git commit -m "chore(release): sync $TAG"
           git push origin "$BRANCH"
 
           gh pr create \


### PR DESCRIPTION
## Summary
- Found a third protection layer on main while merging #141 and #143 by hand: a classic branch protection rule, separate from the two rulesets already known, requiring all 7 CI check contexts to have genuinely run and passed, with admin enforcement on so no bypass is possible for it at all.
- The sync PR commits carried [skip ci], so no checks ever ran on them, making every sync PR structurally unmergeable regardless of admin rights. Had to amend both existing branches by hand to drop it and let CI run before either could merge.
- Dropping [skip ci] from the workflow template is safe now that the release workflow only runs on workflow_dispatch, so this commit can no longer trigger a recursive release the way it could under the old automatic trigger.

## Test plan
- [x] YAML syntax validated
- [x] npx prettier --check on the changed file
- [x] Already validated live: amending #141 and #143 to drop [skip ci] let CI run and both merged cleanly afterward