### PR TITLE
chore(deps-dev): bump doc-sync-check from 1.5.0 to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitest/coverage-v8": "^4.1.9",
-        "doc-sync-check": "^1.5.0",
+        "doc-sync-check": "^1.6.0",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.8.0",
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/doc-sync-check": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/doc-sync-check/-/doc-sync-check-1.5.0.tgz",
-      "integrity": "sha512-hxmhCcoYg/zYmZBF3ZfxsHRuYjnLTtAnKV+Bp+oL72Ar93+gmcNT+0RKVE36wRku2MmfaUvNve5hB+k18/1TsQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/doc-sync-check/-/doc-sync-check-1.6.0.tgz",
+      "integrity": "sha512-BmEZ3t4UEeWi/SF8j5zK3z6xsi7QNH4sOerG6pd6f2256KMAYtIsiw2iNXeyEDg6IEvmR/3cMNE0s4vGRjNJTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^4.1.9",
-    "doc-sync-check": "^1.5.0",
+    "doc-sync-check": "^1.6.0",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.8.0",


### PR DESCRIPTION
## Summary
- Bumped doc-sync-check from 1.5.0 to 1.6.0. Release notes: fixes return-type inference and deprecated doc matching (closes upstream issues 35 and 33), adds automatic loading of a .doc-sync-checkrc.json config file with a --config flag for a custom path, and exits non-zero on unexpected CLI errors.
- This repo has no config file and passes flags directly (src --include docs/api-signatures.md --strict), so the new config-loading behavior does not change anything here, since explicit CLI flags take precedence.
- Verified docs:sync still reports 100 percent coverage with no drift after the bump, so the return-type inference fix did not surface anything new.

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:coverage (100 percent coverage, 66 tests)
- [x] npm run build
- [x] npm run docs:sync (100 percent coverage, no drift)
- [x] npx prettier --check on the changed files