### PR TITLE
chore: add semver-tiered dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary
- Dependabot cooldown only applies to version updates, not security updates, and has no CVE-severity dimension, only semver bump size, so tiered by that instead: patch bumps open after 3 days, minor after 7, major after 14, with default-days: 7 as the fallback for any dependency without semver-tiered support.
- This gives higher-risk major bumps more time for upstream issues to surface before this repo picks them up, while keeping low-risk patches flowing quickly. Confirmed npm/Yarn is on the list of ecosystems that support the semver-tiered options.
- Security updates are unaffected either way, since cooldown never applies to them.

## Test plan
- [x] YAML syntax validated
- [x] npx prettier --check on the changed file
- [ ] Full behavior confirmed on Dependabot's next scheduled run